### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-##Change Log##
+## Change Log ##
 
 - 2013/10/18 : Support `ng-show`, `ng-hide` feature.
 - 2013/10/17 : Fix the problems in `angularjs 1.2.0-rc.3`.
 
-##About ngAnimate##
+## About ngAnimate ##
 ngAnimate is the best effect solution made for AngularJS.
 
 ngAnimate only supports `angularjs 1.2` - because it based on the AngularJS 1.2 extras `ngAnimate.js` module.
 
-##Animations classes##
+## Animations classes ##
 - toggle
 - spin-toggle
 - slide-left
@@ -26,7 +26,7 @@ ngAnimate only supports `angularjs 1.2` - because it based on the AngularJS 1.2 
 - rotate-in
 - more if you have :)
 
-##How to use?##
+## How to use? ##
 1. Add `ngAnimate.js` first. (from angularjs1.2 extras)
 2. Add `ng-animate.css` to you website.
 3. Add `animate class` in html elements which you want have some effect.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
